### PR TITLE
Fix API workflow endpoints

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,9 @@
-from fastapi import FastAPI, Request
+"""FastAPI application entry point."""
+
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from apps.api.routers import reports
+
+from apps.api.routers import ai, clients, disputes, reports
 
 app = FastAPI(title="UFML API", version="0.1.0")
 
@@ -25,3 +28,6 @@ async def _boot():
     print(">>> Allow Origins: http://127.0.0.1:3000, http://localhost:3000 <<<")
 
 app.include_router(reports.router, prefix="/reports", tags=["reports"])
+app.include_router(ai.router, prefix="/ai", tags=["ai"])
+app.include_router(clients.router, prefix="/clients", tags=["clients"])
+app.include_router(disputes.router, prefix="/disputes", tags=["disputes"])

--- a/apps/api/routers/reports.py
+++ b/apps/api/routers/reports.py
@@ -1,5 +1,6 @@
 import io, uuid, time, json
 from typing import List
+
 from fastapi import APIRouter, UploadFile, File, HTTPException, Request
 from pydantic import BaseModel
 import fitz  # PyMuPDF
@@ -16,6 +17,10 @@ class ReportOut(BaseModel):
     filename: str
     pages: int
     text_len: int
+
+
+class ReportAnalysisRequest(BaseModel):
+    report_id: str
 
 @router.get("")
 def list_reports() -> List[ReportOut]:
@@ -113,8 +118,10 @@ def delete_report(report_id: str):
     return {"deleted": True}
 
 @router.post("/analyze")
-async def analyze_report(request: Request, report_id: str):
+async def analyze_report(request: Request, payload: ReportAnalysisRequest):
     """Analyze a report using AI"""
+    report_id = payload.report_id
+
     report = next((r for r in REPORTS if r["id"] == report_id), None)
     if not report:
         raise HTTPException(404, "Report not found")


### PR DESCRIPTION
## Summary
- register the AI, client, and dispute routers with the FastAPI app so the workflow endpoints are reachable
- adjust the report analysis endpoint to accept the JSON payload used by the workflow script

## Testing
- python test-backend.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de10e1f8a48320aeb9e959f4c03acd