### PR TITLE
fix: proxy report uploads through next api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,6 +127,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+!apps/web/app/lib/
 
 # PyInstaller
 *.manifest

--- a/apps/web/app/api/reports/upload/route.ts
+++ b/apps/web/app/api/reports/upload/route.ts
@@ -1,0 +1,95 @@
+import { NextResponse } from 'next/server';
+import { CONFIG } from '@/app/config';
+
+const UPSTREAM_PATH = '/reports/upload';
+
+function toErrorResponse(message: string, status: number) {
+  return NextResponse.json({ detail: message }, { status });
+}
+
+export async function POST(request: Request) {
+  if (CONFIG.USE_MOCKS) {
+    return toErrorResponse('Report uploads are disabled while mocks are enabled.', 503);
+  }
+
+  let incomingForm: FormData;
+  try {
+    incomingForm = await request.formData();
+  } catch (error) {
+    console.error('Failed to read incoming upload form data:', error);
+    return toErrorResponse('Invalid upload payload.', 400);
+  }
+
+  const file = incomingForm.get('file');
+  if (!(file instanceof File)) {
+    return toErrorResponse('A PDF file is required for upload.', 400);
+  }
+
+  const clientIdEntry = incomingForm.get('client_id') ?? incomingForm.get('user_id');
+  const bureauEntry = incomingForm.get('bureau');
+
+  if (typeof clientIdEntry !== 'string' || clientIdEntry.trim() === '') {
+    return toErrorResponse('A client identifier must be provided.', 400);
+  }
+
+  if (typeof bureauEntry !== 'string' || bureauEntry.trim() === '') {
+    return toErrorResponse('A credit bureau selection is required.', 400);
+  }
+
+  const outboundForm = new FormData();
+  for (const [key, value] of incomingForm.entries()) {
+    if (key === 'file') {
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      outboundForm.append(key, value);
+    }
+  }
+
+  outboundForm.set('client_id', clientIdEntry);
+  outboundForm.set('user_id', clientIdEntry);
+  outboundForm.set('bureau', bureauEntry);
+  outboundForm.set('file', file);
+
+  const upstreamUrl = `${CONFIG.API_URL}${UPSTREAM_PATH}`;
+
+  let upstreamResponse: Response;
+  try {
+    const headers = new Headers();
+    const authorization = request.headers.get('authorization');
+    if (authorization) {
+      headers.set('authorization', authorization);
+    }
+
+    const cookie = request.headers.get('cookie');
+    if (cookie) {
+      headers.set('cookie', cookie);
+    }
+
+    upstreamResponse = await fetch(upstreamUrl, {
+      method: 'POST',
+      body: outboundForm,
+      headers
+    });
+  } catch (error) {
+    console.error('Failed to reach upstream reports service:', error);
+    return toErrorResponse(
+      `Unable to reach the reports service at ${upstreamUrl}. Ensure the backend is running and accessible.`,
+      502
+    );
+  }
+
+  const responseHeaders = new Headers();
+  const contentType = upstreamResponse.headers.get('content-type');
+  if (contentType) {
+    responseHeaders.set('content-type', contentType);
+  }
+
+  const body = await upstreamResponse.arrayBuffer();
+
+  return new NextResponse(body, {
+    status: upstreamResponse.status,
+    headers: responseHeaders
+  });
+}

--- a/apps/web/app/lib/upload.ts
+++ b/apps/web/app/lib/upload.ts
@@ -1,0 +1,67 @@
+export interface ReportOut {
+  id: string;
+  filename: string;
+  pages: number;
+  text_len: number;
+}
+
+export async function uploadPdf(file: File, clientId: string, bureau: string): Promise<ReportOut> {
+  const formData = new FormData();
+  formData.append('file', file);
+  formData.append('client_id', clientId);
+  formData.append('user_id', clientId); // legacy name used by some endpoints
+  formData.append('bureau', bureau);
+
+  let response: Response;
+  try {
+    response = await fetch('/api/reports/upload', {
+      method: 'POST',
+      body: formData
+    });
+  } catch (error) {
+    if (error instanceof TypeError) {
+      throw new Error(
+        'Unable to reach the Next.js API route. Ensure the frontend dev server is running.'
+      );
+    }
+
+    throw new Error(
+      error instanceof Error ? error.message : 'Unexpected network error while uploading the report.'
+    );
+  }
+
+  if (!response.ok) {
+    const contentType = response.headers.get('content-type') ?? '';
+    let errorMessage = `Upload failed with status ${response.status}`;
+
+    if (contentType.includes('application/json')) {
+      try {
+        const errorData = await response.json();
+        const detail = errorData?.detail ?? errorData?.message ?? errorData?.error;
+        if (typeof detail === 'string' && detail.trim()) {
+          errorMessage = detail;
+        }
+      } catch (error) {
+        console.error('Failed to parse error response as JSON:', error);
+      }
+    } else {
+      try {
+        const text = await response.text();
+        if (text.trim()) {
+          errorMessage = text;
+        }
+      } catch (error) {
+        console.error('Failed to read error response text:', error);
+      }
+    }
+
+    throw new Error(errorMessage);
+  }
+
+  try {
+    const data = (await response.json()) as ReportOut;
+    return data;
+  } catch (error) {
+    throw new Error('Failed to parse upload response.');
+  }
+}


### PR DESCRIPTION
## Summary
- add a Next.js API route that proxies report uploads to the upstream service and normalises validation errors
- update the frontend upload helper to target the local API route while preserving detailed error handling

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68de176670088320b55ffdfd5b9ca1bf