### PR TITLE
Include clients router and related endpoints

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,14 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from apps.api.routers import reports
+from .routers import clients, credit_bureaus, disputes, relief, reports
+
+try:
+    from .routers import mail
+except ModuleNotFoundError as mail_import_error:  # Optional dependency (lob)
+    mail = None
+    _mail_import_error = mail_import_error
+else:
+    _mail_import_error = None
 
 app = FastAPI(title="UFML API", version="0.1.0")
 
@@ -14,9 +22,11 @@ app.add_middleware(
     expose_headers=["X-Request-ID"],
 )
 
+
 @app.get("/healthz")
 def healthz():
     return {"ok": True}
+
 
 # Log on startup so you KNOW this file is the one running
 @app.on_event("startup")
@@ -24,4 +34,21 @@ async def _boot():
     print(">>> UFML API STARTED WITH CORS ENABLED <<<")
     print(">>> Allow Origins: http://127.0.0.1:3000, http://localhost:3000 <<<")
 
+
 app.include_router(reports.router, prefix="/reports", tags=["reports"])
+app.include_router(clients.router, prefix="/clients", tags=["clients"])
+app.include_router(disputes.router, prefix="/disputes", tags=["disputes"])
+app.include_router(relief.router, prefix="/relief", tags=["relief"])
+if mail is not None:
+    app.include_router(mail.router, prefix="/mail", tags=["mail"])
+else:
+    print(
+        ">>> Mail router disabled: optional dependency missing ->",
+        repr(_mail_import_error),
+    )
+
+app.include_router(
+    credit_bureaus.router,
+    prefix="/credit-bureaus",
+    tags=["credit-bureaus"],
+)


### PR DESCRIPTION
## Summary
- include the clients, disputes, relief, mail, and credit bureau routers on the FastAPI app so frontend screens can call their APIs
- guard the mail router import so the API can still boot when the optional lob dependency is unavailable

## Testing
- PYTHONPATH=.:apps/api uvicorn apps.api.main:app --host 0.0.0.0 --port 8000
- curl -s http://127.0.0.1:8000/clients | jq

------
https://chatgpt.com/codex/tasks/task_e_68de1768704c8320a5ede524b743d651